### PR TITLE
chore: fix Elixir 1.18 warning

### DIFF
--- a/lib/assertions/comparisons.ex
+++ b/lib/assertions/comparisons.ex
@@ -13,7 +13,7 @@ defmodule Assertions.Comparisons do
   def compare_lists(left, right, comparison \\ &Kernel.==/2)
       when is_list(left) and is_list(right) do
     {left_diff, right_diff} =
-      Enum.reduce(1..length(left), {left, right}, &compare(&1, &2, comparison))
+      Enum.reduce(1..length(left)//1, {left, right}, &compare(&1, &2, comparison))
 
     {left_diff, right_diff, left_diff == [] and right_diff == []}
   end


### PR DESCRIPTION
Fixes an Elixir 1.18 warning during server tests:

```
warning: Range.new/2 and first..last default to a step of -1 when last < first. Use Range.new(first, last, -1) or first..last//-1, or pass 1 if that was your intention
  (assertions 0.20.1) lib/assertions/comparisons.ex:16: Assertions.Comparisons.compare_lists/3
  test/hiive/tasks/transaction_tasks_test.exs:222: Hiive.Tasks.TransactionTasksTest."test backfill_transaction_modification/3 [ when backfilling a transaction modification ] no acknowledgments are created"/1
  (ex_unit 1.18.2) lib/ex_unit/runner.ex:511: ExUnit.Runner.exec_test/2
  (stdlib 6.2) timer.erl:595: :timer.tc/2
  (ex_unit 1.18.2) lib/ex_unit/runner.ex:433: anonymous fn/6 in ExUnit.Runner.spawn_test_monitor/4
```